### PR TITLE
Create browser RDS terraform resources in test env

### DIFF
--- a/infra/envs/test/main.tf
+++ b/infra/envs/test/main.tf
@@ -31,3 +31,15 @@ module "ledger" {
   db_instance_count = "${var.db_instance_count}"
   preferred_maintenance_window = "${var.preferred_maintenance_window}"
 }
+
+module "browser" {
+  source = "../../modules/backend/browser"
+
+  deployment_stage = "${var.deployment_stage}"
+
+  // Database
+  db_username = "${var.browser_db_username}"
+  db_password = "${var.browser_db_password}"
+  db_instance_count = "${var.browser_db_instance_count}"
+  preferred_maintenance_window = "${var.browser_preferred_maintenance_window}"
+}

--- a/infra/envs/test/terraform.tfvars.example
+++ b/infra/envs/test/terraform.tfvars.example
@@ -1,7 +1,13 @@
 deployment_stage = "XXX"
 
-// RDS
+// Ledger RDS
 db_username = "xxxxxxxx"
 db_password = "xxxxxxxxxxxxx"
 db_instance_count = 1
 preferred_maintenance_window = "sat:09:08-sat:09:38"
+
+// Browser RDS
+browser_db_username = "xxxxxxxx"
+browser_db_password = "xxxxxxxxxxxxx"
+browser_db_instance_count = 1
+browser_preferred_maintenance_window = "sat:09:08-sat:09:38"

--- a/infra/envs/test/variables.tf
+++ b/infra/envs/test/variables.tf
@@ -2,7 +2,7 @@ variable "deployment_stage" {
   type = string
 }
 
-// RDS
+// Ledger RDS
 
 variable "db_username" {
   type = string
@@ -14,5 +14,20 @@ variable "db_instance_count" {
   type = string
 }
 variable "preferred_maintenance_window" {
+  type = string
+}
+
+// Browser RDS
+
+variable "browser_db_username" {
+  type = string
+}
+variable "browser_db_password" {
+  type = string
+}
+variable "browser_db_instance_count" {
+  type = string
+}
+variable "browser_preferred_maintenance_window" {
   type = string
 }

--- a/infra/modules/backend/browser/rds.tf
+++ b/infra/modules/backend/browser/rds.tf
@@ -1,0 +1,57 @@
+resource "aws_rds_cluster_instance" "cluster_instances" {
+  count                           = var.db_instance_count
+  identifier                      = "browser-cluster-${var.deployment_stage}-${count.index}"
+  cluster_identifier              = aws_rds_cluster.browser.id
+  instance_class                  = "db.r4.large"
+  publicly_accessible             = "true"
+  engine                          = "aurora-mysql"
+  engine_version                  = "5.7.mysql_aurora.2.07.1"
+  auto_minor_version_upgrade      = "true"
+  performance_insights_enabled    = "true"
+  preferred_maintenance_window =    var.preferred_maintenance_window
+}
+
+resource "aws_rds_cluster" "browser" {
+  cluster_identifier              = "dcp-browser-${var.deployment_stage}"
+  engine                          = "aurora-mysql"
+  engine_version                  = "5.7.mysql_aurora.2.07.1"
+  availability_zones              = ["us-east-1a", "us-east-1c", "us-east-1d"]
+  database_name                   = "browser_${var.deployment_stage}"
+  master_username                 = var.db_username
+  master_password                 = var.db_password
+  backup_retention_period         = 7
+  port                            = 5432
+  preferred_backup_window         = "07:27-07:57"
+  preferred_maintenance_window    = var.preferred_maintenance_window
+  storage_encrypted               = "true"
+  vpc_security_group_ids          = [aws_security_group.rds_mysql.id]
+  db_cluster_parameter_group_name = "default.aurora-mysql5.7"
+  final_snapshot_identifier       = "dcp-browser-${var.deployment_stage}"
+}
+
+resource "aws_default_vpc" "default" {
+  tags = {
+    Name = "Default VPC"
+  }
+}
+
+resource "aws_security_group" "rds_mysql" {
+  name          = "dcp-browser-${var.deployment_stage}-rds-mysql-sg"
+  description   = "DCP browser rds security group"
+  vpc_id        = aws_default_vpc.default.id
+
+  ingress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "all"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/infra/modules/backend/browser/variables.tf
+++ b/infra/modules/backend/browser/variables.tf
@@ -1,0 +1,18 @@
+variable "deployment_stage" {
+  type = string
+}
+
+// RDS
+
+variable "db_username" {
+  type = string
+}
+variable "db_password" {
+  type = string
+}
+variable "db_instance_count" {
+  type = string
+}
+variable "preferred_maintenance_window" {
+  type = string
+}


### PR DESCRIPTION
Creates an RDS Aurora MySQL cluster via terraform in the `test` env for the browser database layer. MySQL is favored over PostgreSQL to optimize for simple query/read performance to support the web app. Version `5.7.mysql_aurora.2.07.1` (latest) is configured, however, due to [limited SQL 5.7 feature support in Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Updates.20180206.html), it isn't clear at this point that this is the right version. Moving forward with latest version, may re-evaluate in the future.

Closes #77