### PR TITLE
Parallelize script to read in metadata files for a project and transform the metadata graph into entities to submit to the Ledger DB. (#85)

### DIFF
--- a/dcp_prototype/backend/wrangling/migrations/metadata_schema_representation/old_entities/old_dataset_metadata.py
+++ b/dcp_prototype/backend/wrangling/migrations/metadata_schema_representation/old_entities/old_dataset_metadata.py
@@ -56,6 +56,7 @@ ENTITY_TYPES = [
     "analysis_file",
 ]
 
+
 class OldDatasetMetadata:
     def __init__(self, sequencing_technology="ss2", s3_uri=None):
         self.sequencing_technology = sequencing_technology
@@ -86,7 +87,6 @@ class OldDatasetMetadata:
         self.locks = {}
         for etype in ENTITY_TYPES:
             self.locks[etype] = threading.Lock()
-
 
     def export_to_spreadsheet(self, spreadsheet_filename):
         """
@@ -285,15 +285,9 @@ class OldDatasetMetadata:
 
         self.publish_mode = True
 
-        self.old_metadata_structure[
-            "Donor Organism"
-        ] = self.donor_organisms.values()
-        self.old_metadata_structure[
-            "Specimen From Organism"
-        ] = self.specimens.values()
-        self.old_metadata_structure[
-            "Cell Suspensions"
-        ] = self.cell_suspensions.values()
+        self.old_metadata_structure["Donor Organism"] = self.donor_organisms.values()
+        self.old_metadata_structure["Specimen From Organism"] = self.specimens.values()
+        self.old_metadata_structure["Cell Suspensions"] = self.cell_suspensions.values()
         self.old_metadata_structure[
             "Library Prep Protocols"
         ] = self.library_preps.values()
@@ -319,7 +313,10 @@ class OldDatasetMetadata:
             donor_organism = OldDonorOrganism()
             donor_organism.populate_from_dcp_one_json_data_frame(row)
             with self.locks[entity_type]:
-                if donor_organism.corresponding_old_id not in self.donor_organisms.keys():
+                if (
+                    donor_organism.corresponding_old_id
+                    not in self.donor_organisms.keys()
+                ):
                     self.donor_organisms[
                         donor_organism.corresponding_old_id
                     ] = donor_organism
@@ -328,7 +325,10 @@ class OldDatasetMetadata:
             specimen_from_organism = OldSpecimenFromOrganism()
             specimen_from_organism.populate_from_dcp_one_json_data_frame(row)
             with self.locks[entity_type]:
-                if specimen_from_organism.corresponding_old_id not in self.specimens.keys():
+                if (
+                    specimen_from_organism.corresponding_old_id
+                    not in self.specimens.keys()
+                ):
                     self.specimens[
                         specimen_from_organism.corresponding_old_id
                     ] = specimen_from_organism
@@ -337,7 +337,10 @@ class OldDatasetMetadata:
             cell_suspension = OldCellSuspension()
             cell_suspension.populate_from_dcp_one_json_data_frame(row)
             with self.locks[entity_type]:
-                if cell_suspension.corresponding_old_id not in self.cell_suspensions.keys():
+                if (
+                    cell_suspension.corresponding_old_id
+                    not in self.cell_suspensions.keys()
+                ):
                     self.cell_suspensions[
                         cell_suspension.corresponding_old_id
                     ] = cell_suspension
@@ -359,13 +362,18 @@ class OldDatasetMetadata:
                     for contributor in contributors:
                         if contributor.name not in self.contributors.keys():
                             self.contributors[contributor.name] = contributor
-                            self.project_contributor_links.append((project, contributor))
+                            self.project_contributor_links.append(
+                                (project, contributor)
+                            )
 
         if entity_type == "sequencing_protocol":
             protocol = OldSequencingProtocol()
             protocol.populate_from_dcp_one_json_data_frame(row)
             with self.locks[entity_type]:
-                if protocol.corresponding_old_id not in self.sequencing_protocols.keys():
+                if (
+                    protocol.corresponding_old_id
+                    not in self.sequencing_protocols.keys()
+                ):
                     self.sequencing_protocols[protocol.corresponding_old_id] = protocol
 
         if entity_type == "sequence_file":
@@ -374,7 +382,9 @@ class OldDatasetMetadata:
             sequence_file.set_s3_uri(self.s3_uri)
             with self.locks[entity_type]:
                 if sequence_file.corresponding_old_id not in self.sequence_files.keys():
-                    self.sequence_files[sequence_file.corresponding_old_id] = sequence_file
+                    self.sequence_files[
+                        sequence_file.corresponding_old_id
+                    ] = sequence_file
 
         if entity_type == "analysis_file":
             analysis_file = OldAnalysisFile()
@@ -382,7 +392,9 @@ class OldDatasetMetadata:
             analysis_file.set_s3_uri(self.s3_uri)
             with self.locks[entity_type]:
                 if analysis_file.corresponding_old_id not in self.analysis_files.keys():
-                    self.analysis_files[analysis_file.corresponding_old_id] = analysis_file
+                    self.analysis_files[
+                        analysis_file.corresponding_old_id
+                    ] = analysis_file
 
         if entity_type == "links":
             with self.locks[entity_type]:

--- a/dcp_prototype/backend/wrangling/migrations/metadata_schema_representation/old_entities/old_dataset_metadata.py
+++ b/dcp_prototype/backend/wrangling/migrations/metadata_schema_representation/old_entities/old_dataset_metadata.py
@@ -24,6 +24,7 @@ from dcp_prototype.backend.wrangling.migrations.metadata_schema_representation.o
 )
 
 from dcp_prototype.backend.wrangling.migrations.utils.util import merge_dictionary_into
+from dcp_prototype.backend.wrangling.migrations.utils.constants import ENTITY_TYPES
 from pandas import DataFrame, ExcelWriter
 import random
 from dcp_prototype.backend.ledger.code.common.ledger_orm import (
@@ -43,18 +44,6 @@ from dcp_prototype.backend.wrangling.migrations.utils.id_generator import (
     hca_accession_transformer,
 )
 import threading
-
-ENTITY_TYPES = [
-    "donor_organism",
-    "specimen_from_organism",
-    "cell_suspension",
-    "library_preparation_protocol",
-    "project",
-    "sequence_file",
-    "links",
-    "sequencing_protocol",
-    "analysis_file",
-]
 
 
 class OldDatasetMetadata:

--- a/dcp_prototype/backend/wrangling/migrations/scripts/migrate_dcp_one_to_dcp_two.py
+++ b/dcp_prototype/backend/wrangling/migrations/scripts/migrate_dcp_one_to_dcp_two.py
@@ -9,10 +9,11 @@ import os.path
 from botocore.exceptions import ClientError
 from flatten_json import flatten
 from dcp_prototype.backend.wrangling.migrations.metadata_schema_representation.old_entities.old_dataset_metadata import (  # noqa
-    ENTITY_TYPES, OldDatasetMetadata,
+    OldDatasetMetadata,
 )
 import json
 from dcp_prototype.backend.ledger.code.common.ledger_orm import DBSessionMaker
+from dcp_prototype.backend.wrangling.migrations.utils.constants import ENTITY_TYPES
 
 import queue
 import threading

--- a/dcp_prototype/backend/wrangling/migrations/scripts/migrate_dcp_one_to_dcp_two.py
+++ b/dcp_prototype/backend/wrangling/migrations/scripts/migrate_dcp_one_to_dcp_two.py
@@ -52,15 +52,15 @@ def order_file_list(file_list):
 
     for file in file_list:
         if "donor_organism" in file:
-            ordered_file_list.append((1,file))
+            ordered_file_list.append((1, file))
         elif "specimen" in file:
-            ordered_file_list.append((2,file))
+            ordered_file_list.append((2, file))
         elif "cell_suspension" in file:
-            ordered_file_list.append((3,file))
+            ordered_file_list.append((3, file))
         elif "links" not in file:
-            ordered_file_list.append((4,file))
+            ordered_file_list.append((4, file))
         elif "links" in file:
-            ordered_file_list.append((5,file))
+            ordered_file_list.append((5, file))
 
     ordered_file_list.sort()
     ordered_file_list = [x[1] for x in ordered_file_list]
@@ -68,6 +68,7 @@ def order_file_list(file_list):
     tend = time.time()
     print("order_file_list:", (tend-tstart))
     return ordered_file_list
+
 
 def consume_file(prefix, bucket, filequeue, dataset_metadata):
     while True:
@@ -115,7 +116,7 @@ def generate_metadata_structure_from_s3_uri(s3_uri, num_threads):
 
     paginator = S3_CLIENT.get_paginator("list_objects")
     page_iterator = paginator.paginate(Bucket=BUCKET_NAME, Prefix=PREFIX)
-    filtered_iterator = page_iterator.search( "Contents[?contains(Key, `.json`)][]")
+    filtered_iterator = page_iterator.search("Contents[?contains(Key, `.json`)][]")
 
     file_list = []
     print("Gather objects: ", end="", flush=True)
@@ -124,12 +125,12 @@ def generate_metadata_structure_from_s3_uri(s3_uri, num_threads):
         if should_process_file(object_filename):
             file_list.append(object_filename.split("/")[-1])
             if len(file_list) % 1000 == 0:
-                print(len(file_list),end=" ", flush=True)
+                print(len(file_list), end=" ", flush=True)
 
     print()
     file_list = order_file_list(file_list)
 
-    #print(f"Files in directory to parse: {file_list}")
+    # print(f"Files in directory to parse: {file_list}")
     print(f"Files in directory to parse: {len(file_list)}")
 
     filequeue = queue.Queue()
@@ -142,7 +143,8 @@ def generate_metadata_structure_from_s3_uri(s3_uri, num_threads):
 
     threads = []
     for i in range(num_threads):
-        t= threading.Thread(target=consume_file, args=(PREFIX, BUCKET_NAME, filequeue, dataset_metadata))
+        t = threading.Thread(target=consume_file,
+                             args=(PREFIX, BUCKET_NAME, filequeue, dataset_metadata))
         t.start()
         threads.append(t)
 
@@ -358,9 +360,9 @@ if __name__ == "__main__":
     tend = time.time()
     print("Generate metadata structure:", (tend-tstart))
 
-    tstart=time.time()
+    tstart = time.time()
     export_old_metadata_to_s3_orm(
         old_metadata, input_directory, "s3" not in input_directory
     )
-    tend=time.time()
+    tend = time.time()
     print("export_old_metadata_to_s3_orm:", (tend-tstart))

--- a/dcp_prototype/backend/wrangling/migrations/utils/constants.py
+++ b/dcp_prototype/backend/wrangling/migrations/utils/constants.py
@@ -124,3 +124,15 @@ SS2_QUANTIFICATION_PROTOCOL = QuantificationProtocol(quantification_software="RS
 X10_QUANTIFICATION_PROTOCOL = QuantificationProtocol(
     quantification_software="HCA Single Cell Tools"
 )
+
+ENTITY_TYPES = [
+    "donor_organism",
+    "specimen_from_organism",
+    "cell_suspension",
+    "library_preparation_protocol",
+    "project",
+    "sequence_file",
+    "links",
+    "sequencing_protocol",
+    "analysis_file",
+]


### PR DESCRIPTION
    First pass:
      1. thread the portion that reads and processes the json files from s3.
      2. add a filter to the paginator to only return json files
      3. avoid O(n^2) algorithm in order_file_list (there could be 100000s of files)
    
    The number of threads can be selected at runtime.
    In the example with 2500 bundles, the time went down from 2-3 hours to a little under 15 minutes
    That was with 16 threads
