### PR TITLE
Updates and fixes to the dcp1 migration script

### DIFF
--- a/dcp_prototype/backend/wrangling/migrations/common/dataset_metadata.py
+++ b/dcp_prototype/backend/wrangling/migrations/common/dataset_metadata.py
@@ -50,6 +50,18 @@ class DatasetMetadata:
         self.process_dissociation_protocol()
         self.process_library_preparation_protocol()
         self.process_enrichment_protocols()
+        self.process_cell_suspension()
+        self.process_organoid()
+        self.process_cell_line()
+
+        # NOTE: this may not be the proper way to get the biosample_category.
+        # This need to be reviewed and checked.
+        if self.entity_data.get("organoid"):
+            self.project.biosample_categories.append("organoid")
+        elif self.entity_data.get("cell_line"):
+            self.project.biosample_categories.append("cell line")
+        elif self.entity_data.get("specimen_from_organism"):
+            self.project.biosample_categories.append("primary tissue")
 
     def validate(self, data):
         """Validate the data with the current artifact schema"""
@@ -117,12 +129,21 @@ class DatasetMetadata:
         for data in self.entity_data.get("donor_organism", []):
             self.process_mappings("donor_organism", data, self.project, mapping, self.missing)
 
+        # This is a special case for one project that lacks an ontology_label for genus_species.
+        # An alternative approach to solve this problem is to provide a list of source mappings for
+        # each destination mapping, in order of preference.  Then iterate through each source mapping
+        # until a match is found.  However, since this only impacts one attribute for one project,
+        # it's simpler to make a special case.
+        if not self.project.donor_species:
+            mapping = ((("genus_species", "*", "text"), "donor_species", append_unique_value_to_attribute),)
+            for data in self.entity_data.get("donor_organism", []):
+                self.process_mappings("donor_organism", data, self.project, mapping, self.missing)
+
     def process_specimen_from_organism(self):
         # specimen_from_organism
         mapping = (
-            (("biomaterial_core", "biomaterial_name"), "biosample_names", append_unique_value_to_attribute),
             (("organ", "ontology_label"), "organs", append_unique_value_to_attribute),
-            (("organ_parts", "*", "ontology_label"), "biosample_categories", append_unique_value_to_attribute),
+            (("organ_parts", "*", "ontology_label"), "biosample_names", append_unique_value_to_attribute),
             (("diseases", "*", "ontology_label"), "biosample_diseases", append_unique_value_to_attribute),
         )
         for data in self.entity_data.get("specimen_from_organism", []):
@@ -164,41 +185,24 @@ class DatasetMetadata:
 
     def process_enrichment_protocols(self):
         mapping = (("markers", "selected_cell_markers", append_unique_value_to_attribute),)
-        for data in self.entity_data.get("cell_suspension", []):
-            self.process_mappings("cell_suspension", data, self.project, mapping, self.missing)
+        for data in self.entity_data.get("enrichment_protocol", []):
+            self.process_mappings("enrichment_protocol", data, self.project, mapping, self.missing)
+
+    def process_organoid(self):
+        mapping = ((("model_organ", "ontology_label"), "organs", append_unique_value_to_attribute),)
+        for data in self.entity_data.get("organoid", []):
+            self.process_mappings("organoid", data, self.project, mapping, self.missing)
+
+    def process_cell_line(self):
+        mapping = ((("model_organ", "ontology_label"), "organs", append_unique_value_to_attribute),)
+
+        for data in self.entity_data.get("cell_line", []):
+            self.process_mappings("cell_line", data, self.project, mapping, self.missing)
 
     def to_dict(self):
         """Return the artifact data as a dict"""
         jdata = json.dumps(self.artifact, default=MetadataBase.serialize)
         return json.loads(jdata)
-
-    def combine_projects(artifact_file, new_artifact):
-        out_project = new_artifact.get("projects")[0]
-        title = out_project.get("title")
-        if os.path.exists(artifact_file):
-            with open(artifact_file) as json_file:
-                data = json.load(json_file)
-                projects = data.get("projects")
-                if projects is None:
-                    print(f"expected 'projects' in {artifact_file}")
-                    sys.exit(1)
-
-                do_append = True
-                for index, project in enumerate(projects):
-                    if project.get("title") == title:
-                        print(f"replaced project {title} in {artifact_file}")
-                        projects[index] = out_project
-                        do_append = False
-                        break
-                if do_append:
-                    print(f"append project {title} in {artifact_file}")
-                    projects.append(out_project)
-                out_dict = data
-        else:
-            out_dict = new_artifact
-            print(f"write project {title} to {artifact_file}")
-
-        return out_dict
 
     def process_mapping(self, source, source_tuple, dest_object, dest_attr, mapfunc):
         """This function locates attributes from source_tuple and maps them into attributes in dest_attr.  The
@@ -247,3 +251,33 @@ class DatasetMetadata:
             except KeyError as e:
                 if source_tuple not in missing:
                     missing[source_tuple] = (label, dest_attr, e)
+
+
+def combine_projects(artifact_file, new_artifact):
+    """Combine a json output from a new artifact into an existing artifact file"""
+    out_project = new_artifact.get("projects")[0]
+    title = out_project.get("title")
+    if os.path.exists(artifact_file):
+        with open(artifact_file) as json_file:
+            data = json.load(json_file)
+            projects = data.get("projects")
+            if projects is None:
+                print(f"expected 'projects' in {artifact_file}")
+                sys.exit(1)
+
+            do_append = True
+            for index, project in enumerate(projects):
+                if project.get("title") == title:
+                    print(f"replaced project {title} in {artifact_file}")
+                    projects[index] = out_project
+                    do_append = False
+                    break
+            if do_append:
+                print(f"append project {title} in {artifact_file}")
+                projects.append(out_project)
+            out_dict = data
+    else:
+        out_dict = new_artifact
+        print(f"write project {title} to {artifact_file}")
+
+    return out_dict

--- a/dcp_prototype/backend/wrangling/migrations/common/metadata.py
+++ b/dcp_prototype/backend/wrangling/migrations/common/metadata.py
@@ -39,7 +39,6 @@ class MetadataProject(MetadataBase):
 
         # specimen_from_organism
         self.biosample_names = []
-        self.biosample_categories = []
         self.biosample_diseases = []
         self.organs = []
 
@@ -59,6 +58,9 @@ class MetadataProject(MetadataBase):
 
         # enrichment_protocol
         self.selected_cell_markers = []
+
+        # server_data
+        self.biosample_categories = []
 
         # TODO: NOT PROCESSED YET
         self.systems = []

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ coverage>=2.0.15
 flake8-black
 jsonschema
 pytest
+requests>=2.22.0

--- a/tests/dcp-prototype/backend/wrangling/fixtures/WongAdultRetina.json
+++ b/tests/dcp-prototype/backend/wrangling/fixtures/WongAdultRetina.json
@@ -122,12 +122,10 @@
         "cataract (disease)"
       ],
       "biosample_names": [
-        "17-011 retina",
-        "17-010 retina",
-        "SC retina"
+        "retinal neural layer"
       ],
       "biosample_categories": [
-        "retinal neural layer"
+        "primary tissue"
       ],
       "biosample_diseases": [
         "normal"


### PR DESCRIPTION
1. fix biosample_names and biosample_categories
2. fix bug in handing of enrichment_protocol
3. workaround for missing donor species in one of the datasets

The biosample_categories may not be correct.  This is the part
that chooses between primary, cell line and organoid.

Issue #176 