### PR TITLE
Create dev deployment for browser

### DIFF
--- a/dcp_prototype/backend/browser/api/Makefile
+++ b/dcp_prototype/backend/browser/api/Makefile
@@ -1,6 +1,7 @@
 SHELL=/bin/bash -o pipefail
 
 # This is set for build reproducibility
+export ACCOUNT_ID=$(shell aws sts get-caller-identity --query Account --output text)
 export APP_NAME=browser-api
 export EXPORT_ENV_VARS_TO_LAMBDA=APP_NAME DEPLOYMENT_STAGE
 export PYTHONHASHSEED=0

--- a/dcp_prototype/backend/browser/iam/policy-templates/browser-api-lambda.json
+++ b/dcp_prototype/backend/browser/iam/policy-templates/browser-api-lambda.json
@@ -17,7 +17,7 @@
         "secretsmanager:GetSecretValue"
       ],
       "Resource": [
-        "arn:aws:secretsmanager:us-east-1:856863240400:secret:dcp/backend/browser/$DEPLOYMENT_STAGE/*"
+        "arn:aws:secretsmanager:us-east-1:$ACCOUNT_ID:secret:dcp/backend/browser/$DEPLOYMENT_STAGE/*"
       ]
     }
   ]

--- a/dcp_prototype/frontend/Makefile
+++ b/dcp_prototype/frontend/Makefile
@@ -1,5 +1,5 @@
 SHELL:=/bin/bash
-export BROWSER_S3=dcp-static-site-$(DEPLOYMENT_STAGE)
+export BROWSER_S3=dcp-site-deployment-$(DEPLOYMENT_STAGE)
 
 ifndef DEPLOYMENT_STAGE
 $(error Please set the DEPLOYMENT_STAGE environment before deploying)

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -10,30 +10,42 @@ terraform {
   backend "s3" {
     encrypt = true
     region  = "us-east-1"
-    profile = "czi-hca-dev"
+    profile = "single-cell-dev"
   }
 }
 
 provider "aws" {
   version = "~> 2.0"
   region  = "us-east-1"
-  profile = "czi-hca-dev"
+  profile = "single-cell-dev"
 }
 
-module "ledger" {
-  source = "../../modules/backend/ledger"
-
-  deployment_stage = "${var.deployment_stage}"
-
-  // Database
-  db_username                  = "${var.db_username}"
-  db_password                  = "${var.db_password}"
-  db_instance_count            = "${var.db_instance_count}"
-  preferred_maintenance_window = "${var.preferred_maintenance_window}"
-}
+//module "ledger" {
+//  source = "../../modules/backend/ledger"
+//
+//  deployment_stage = "${var.deployment_stage}"
+//
+//  // Database
+//  db_username                  = "${var.db_username}"
+//  db_password                  = "${var.db_password}"
+//  db_instance_count            = "${var.db_instance_count}"
+//  preferred_maintenance_window = "${var.preferred_maintenance_window}"
+//}
 
 module "browser_frontend" {
   source = "../../modules/frontend/browser"
 
   deployment_stage = "${var.deployment_stage}"
+}
+
+module "browser_backend" {
+  source = "../../modules/backend/browser"
+
+  deployment_stage = "${var.deployment_stage}"
+
+  // Database
+  db_username                  = "${var.browser_db_username}"
+  db_password                  = "${var.browser_db_password}"
+  db_instance_count            = "${var.browser_db_instance_count}"
+  preferred_maintenance_window = "${var.browser_preferred_maintenance_window}"
 }

--- a/infra/envs/dev/terraform.tfvars.example
+++ b/infra/envs/dev/terraform.tfvars.example
@@ -1,7 +1,13 @@
 deployment_stage = "XXX"
 
-// RDS
+// Ledger RDS
 db_username = "xxxxxxxx"
 db_password = "xxxxxxxxxxxxx"
 db_instance_count = 1
 preferred_maintenance_window = "sat:09:08-sat:09:38"
+
+// Browser RDS
+browser_db_username = "xxxxxxxx"
+browser_db_password = "xxxxxxxxxxxxx"
+browser_db_instance_count = 1
+browser_preferred_maintenance_window = "sat:09:08-sat:09:38"

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -16,3 +16,18 @@ variable "db_instance_count" {
 variable "preferred_maintenance_window" {
   type = string
 }
+
+// Browser RDS
+
+variable "browser_db_username" {
+  type = string
+}
+variable "browser_db_password" {
+  type = string
+}
+variable "browser_db_instance_count" {
+  type = string
+}
+variable "browser_preferred_maintenance_window" {
+  type = string
+}

--- a/infra/modules/frontend/browser/static_website.tf
+++ b/infra/modules/frontend/browser/static_website.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket" "gatsby_static_bucket" {
 
-  bucket = "dcp-static-site-${var.deployment_stage}"
+  bucket = "dcp-site-deployment-${var.deployment_stage}"
 
   website {
     index_document = "index.html"


### PR DESCRIPTION
These changes create terraform resources for the browser's `dev` environment. These changes coincide with the AWS account migration from `856863240400` (czi-hca-dev) to `699936264352` (single-cell-dev). As we spin up in the new account, the browser infrastructure will deprecate the `test` environment in favor of per-developer test environments, `dev` and `prod`.

The account migration for the browser is complete with the site running at: http://dcp-site-deployment-dev.s3-website-us-east-1.amazonaws.com/ . Since its bucket hosted, we can preserve the old URL (dcp-static-site) after destroying resources in the old account.

Note:
Ledger resources have been commented out in terraform (`main.tf`) for the time being.

Closes #198 