### PR TITLE
Implement file download API

### DIFF
--- a/dcp_prototype/backend/browser/code/common/db_utils.py
+++ b/dcp_prototype/backend/browser/code/common/db_utils.py
@@ -6,6 +6,7 @@ sys.path.insert(0, pkg_root)  # noqa
 
 from browser.code.common.browser_orm import (
     DBSessionMaker,
+    File,
     LibraryPrepProtocol,
     Tissue,
     Species,
@@ -15,7 +16,7 @@ from browser.code.common.browser_orm import (
 )
 
 
-def _get_project_assays(project_id, session=None):
+def get_project_assays(project_id, session=None):
     """
     Query the DB to return all assays that are represented in a given project.
     :param project_id: Project to return assays for
@@ -39,7 +40,7 @@ def _get_project_assays(project_id, session=None):
     return assays
 
 
-def _get_project_tissues(project_id, session=None):
+def get_project_tissues(project_id, session=None):
     """
     Query the DB to return all tissues that are represented in a given project.
     :param project_id: Project to return tissues for
@@ -60,7 +61,7 @@ def _get_project_tissues(project_id, session=None):
     return tissues
 
 
-def _get_project_species(project_id, session=None):
+def get_project_species(project_id, session=None):
     """
     Query the DB to return all species that are represented in a given project.
     :param project_id: Project to return species for
@@ -79,3 +80,27 @@ def _get_project_species(project_id, session=None):
         species.append(result.Species.species_ontology)
 
     return species
+
+
+def get_downloadable_project_files(project_id, session=None):
+    """
+    Query the DB to return all downloadable files for a project.
+    :param project_id: Project to return files for
+    :param session: SQLAlchemy DBSession
+    :return: list of file metadata objects
+    """
+    files = []
+    for file in session.query(File).filter(File.project_id == project_id).filter(File.file_format == "loom"):
+        files.append(
+            {
+                "id": file.id,
+                "filename": file.filename,
+                "file_format": file.file_format,
+                "file_size": file.file_size,
+                "species": file.species,
+                "library_construction_method_ontology": file.library_construction_method_ontology,
+                "tissue_ontology": file.tissue_ontology,
+            }
+        )
+
+    return files

--- a/dcp_prototype/backend/browser/code/common/s3_utils.py
+++ b/dcp_prototype/backend/browser/code/common/s3_utils.py
@@ -1,0 +1,25 @@
+import os
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def generate_file_url(file_prefix, expiration=3600):
+    """
+    Generate a presigned URL for a file for user download.
+    :param file_prefix: S3 prefix location of the file
+    :param expiration: Presigned URL expiration in seconds
+    :return: Presigned URL to download the requested file
+    """
+    s3_client = boto3.client("s3")
+    bucket_name = f"dcp-browser-bucket-{os.environ['DEPLOYMENT_STAGE']}"
+
+    try:
+        response = s3_client.generate_presigned_url(
+            "get_object", Params={"Bucket": bucket_name, "Key": file_prefix}, ExpiresIn=expiration
+        )
+    except ClientError as e:
+        print(f"Failed to generate presigned URL for {file_prefix} with error: {e}")
+        return ""
+
+    return response

--- a/dcp_prototype/backend/browser/iam/policy-templates/browser-api-lambda.json
+++ b/dcp_prototype/backend/browser/iam/policy-templates/browser-api-lambda.json
@@ -19,6 +19,16 @@
       "Resource": [
         "arn:aws:secretsmanager:us-east-1:$ACCOUNT_ID:secret:dcp/backend/browser/$DEPLOYMENT_STAGE/*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::dcp-browser-bucket-$DEPLOYMENT_STAGE",
+        "arn:aws:s3:::dcp-browser-bucket-$DEPLOYMENT_STAGE/*"
+      ]
     }
   ]
 }

--- a/infra/modules/backend/browser/s3.tf
+++ b/infra/modules/backend/browser/s3.tf
@@ -1,0 +1,4 @@
+resource "aws_s3_bucket" "browser_s3_bucket" {
+  bucket = "dcp-browser-bucket-${var.deployment_stage}"
+  acl    = "private"
+}


### PR DESCRIPTION
These changes enable downloading of project loom files via presigned S3 URLs. Download URLs are currently set to expire in 24 hours.

- [x] update GET /projects/{`pid`}/files to return available project loom files
- [x] update GET /files/{`fid`} to return a generate a presigned URL
- [ ] unit tests

Closes #130 
Closes #148